### PR TITLE
Use peg as the parser generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: MacroJazz CI workflow
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+# TODO: enable Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "ariadne"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
+dependencies = [
+ "yansi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +64,8 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 name = "macrojazz"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "ariadne",
  "codemap",
  "codemap-diagnostic",
  "peg",
@@ -144,3 +161,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.58"
+ariadne = "0.1.5"
 codemap = "0.1.3"
 codemap-diagnostic = "0.1.1"
 peg = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Macrojazz
 
-## Build status: https://github.com/Sup3Legacy/macrojazz/workflows/ci/badge.svg
+## Build status: ![](https://github.com/Sup3Legacy/macrojazz/workflows/ci/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Macrojazz
+
+## Build status: https://github.com/Sup3Legacy/macrojazz/workflows/ci/badge.svg

--- a/src/common/location.rs
+++ b/src/common/location.rs
@@ -55,6 +55,10 @@ impl Location {
         self.range
     }
 
+    pub fn extend(self, start: usize, end: usize) -> std::ops::Range<usize> {
+        self.range.start.min(start)..(self.range.end.max(end))
+    }
+
     pub fn union(self, other: Self) -> std::ops::Range<usize> {
         (self.range.start.min(other.range.start))..(self.range.end.min(other.range.end))
     }

--- a/src/common/location.rs
+++ b/src/common/location.rs
@@ -1,11 +1,20 @@
-use codemap;
+use ariadne::Source;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct Location {
-    file: Arc<codemap::File>,
+    file: Arc<Source>,
     start: usize,
     end: usize,
+}
+
+impl std::fmt::Debug for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.debug_struct("Location")
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .finish()
+    }
 }
 
 #[derive(Debug)]
@@ -15,7 +24,7 @@ pub struct Located<T> {
 }
 
 impl Location {
-    pub fn new(file: &Arc<codemap::File>, start: usize, end: usize) -> Self {
+    pub fn new(file: &Arc<Source>, start: usize, end: usize) -> Self {
         Self {
             file: file.clone(),
             start,
@@ -25,7 +34,7 @@ impl Location {
 }
 
 impl<T> Located<T> {
-    pub fn new(inner: T, file: &Arc<codemap::File>, start: usize, end: usize) -> Self {
+    pub fn new(inner: T, file: &Arc<Source>, start: usize, end: usize) -> Self {
         Self {
             inner,
             loc: Location::new(file, start, end),

--- a/src/common/location.rs
+++ b/src/common/location.rs
@@ -1,43 +1,102 @@
-use ariadne::Source;
-use std::sync::Arc;
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SrcId(usize);
 
-#[derive(Clone)]
-pub struct Location {
-    file: Arc<Source>,
-    start: usize,
-    end: usize,
-}
-
-impl std::fmt::Debug for Location {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        f.debug_struct("Location")
-            .field("start", &self.start)
-            .field("end", &self.end)
-            .finish()
+impl SrcId {
+    pub fn empty() -> Self {
+        Self(0)
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub struct Location {
+    file: SrcId,
+    range: std::ops::Range<usize>,
+}
+
+impl std::fmt::Debug for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "range: {:?}", self.range)
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct Located<T> {
     inner: T,
     loc: Location,
 }
 
 impl Location {
-    pub fn new(file: &Arc<Source>, start: usize, end: usize) -> Self {
+    pub fn new(file: SrcId, start: usize, end: usize) -> Self {
         Self {
-            file: file.clone(),
-            start,
-            end,
+            file,
+            range: start..end,
         }
+    }
+
+    pub fn empty(start: usize, end: usize) -> Self {
+        Self {
+            file: SrcId::empty(),
+            range: start..end,
+        }
+    }
+
+    pub fn from_range(file: SrcId, range: std::ops::Range<usize>) -> Self {
+        Self { file, range }
+    }
+
+    pub fn empty_from_range(range: std::ops::Range<usize>) -> Self {
+        Self {
+            file: SrcId::empty(),
+            range,
+        }
+    }
+
+    pub fn get_range(self) -> std::ops::Range<usize> {
+        self.range
+    }
+
+    pub fn union(self, other: Self) -> std::ops::Range<usize> {
+        (self.range.start.min(other.range.start))..(self.range.end.min(other.range.end))
     }
 }
 
 impl<T> Located<T> {
-    pub fn new(inner: T, file: &Arc<Source>, start: usize, end: usize) -> Self {
+    pub fn new(inner: T, file: SrcId, start: usize, end: usize) -> Self {
         Self {
             inner,
             loc: Location::new(file, start, end),
+        }
+    }
+
+    pub fn from_range(inner: T, file: SrcId, range: std::ops::Range<usize>) -> Self {
+        Self {
+            inner,
+            loc: Location::from_range(file, range),
+        }
+    }
+
+    pub fn empty_from_range(inner: T, range: std::ops::Range<usize>) -> Self {
+        Self {
+            inner,
+            loc: Location::empty_from_range(range),
+        }
+    }
+
+    pub fn get_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn get_loc(&self) -> Location {
+        self.loc.clone()
+    }
+
+    pub fn map<U, F>(self, f: F) -> Located<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        Located {
+            inner: f(self.inner),
+            loc: self.loc,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod parser;
 fn main() {
     let code = r"
 node test<n: int>(a: [!n], b: [1]) -> (c: [n]) {
-    c = a == 1 != 2;
+    c = f<a,if a==b {a} else {b}>(1, 2) ^ 2 | a[..=n - 2] . if n == n { b } else { c };
 }
 ";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,15 @@
-#[allow(dead_code)]
-
-mod parser;
 mod common;
+#[allow(dead_code)]
+mod parser;
 
 fn main() {
-    println!("Hello, world!");
+    let code = r"
+node test<n: int>(a: [!n], b: [1]) -> (c: [n]) {
+    c = a;
+}
+";
+
+    let res = parser::parse_single(code, common::location::SrcId::empty());
+
+    println!("{:#?}", res);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod parser;
 fn main() {
     let code = r"
 node test<n: int>(a: [!n], b: [1]) -> (c: [n]) {
-    c = a;
+    c = a == 1 != 2;
 }
 ";
 

--- a/src/parser/.mod.rs.rustfmt
+++ b/src/parser/.mod.rs.rustfmt
@@ -128,58 +128,6 @@ peg::parser! {
                     }, loc_x.union(loc_y))
                 }
 
-               x:(@) _ start:position!() "!=" end:position!() _ y:@ {
-                    let loc_x = x.get_loc();
-                    let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::NEquals, start..end),
-                        lhs: Box::new(x),
-                        rhs: Box::new(y),
-                    }, loc_x.union(loc_y))
-                }
-
-                --
-
-               x:(@) _ start:position!() ">" end:position!() _ y:@ {
-                    let loc_x = x.get_loc();
-                    let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::Greater, start..end),
-                        lhs: Box::new(x),
-                        rhs: Box::new(y),
-                    }, loc_x.union(loc_y))
-                }
-
-               x:(@) _ start:position!() ">=" end:position!() _ y:@ {
-                    let loc_x = x.get_loc();
-                    let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::GreaterEq, start..end),
-                        lhs: Box::new(x),
-                        rhs: Box::new(y),
-                    }, loc_x.union(loc_y))
-                }
-
-               x:(@) _ start:position!() "<" end:position!() _ y:@ {
-                    let loc_x = x.get_loc();
-                    let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::Smaller, start..end),
-                        lhs: Box::new(x),
-                        rhs: Box::new(y),
-                    }, loc_x.union(loc_y))
-                }
-
-               x:(@) _ start:position!() "<=" end:position!() _ y:@ {
-                    let loc_x = x.get_loc();
-                    let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::SmallerEq, start..end),
-                        lhs: Box::new(x),
-                        rhs: Box::new(y),
-                    }, loc_x.union(loc_y))
-                }
-
                 l:literal(file)
                     {
                         let loc = l.get_loc();

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -40,6 +40,7 @@ pub enum EarlyOperator {
 pub enum EarlyMonOp {
     Minus,
     Not,
+    BitNot,
 }
 
 /// A immediate

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -30,6 +30,11 @@ pub enum EarlyBinOp {
     BitXOr,
 }
 
+#[derive(Debug)]
+pub enum EarlyOperator {
+    Reg,
+}
+
 /// A 1-adic operator
 #[derive(Debug)]
 pub enum EarlyMonOp {
@@ -49,15 +54,15 @@ pub enum EarlyIndex {
     Range {
         lhs: Option<Located<EarlyExpression>>,
         rhs: Option<Located<EarlyExpression>>,
-        rhs_iinclusive: bool,
+        rhs_inclusive: bool,
     },
     Simple(Located<EarlyExpression>),
 }
 
 #[derive(Debug)]
 pub enum EarlyExpression {
-    Ident(Located<EarlyIdentifier>),
-    Literal(Located<EarlyLiteral>),
+    Ident(EarlyIdentifier),
+    Literal(EarlyLiteral),
     MonOp {
         operand: Box<Located<EarlyExpression>>,
         operator: Located<EarlyMonOp>,
@@ -76,33 +81,35 @@ pub enum EarlyExpression {
         lhs: Box<Located<EarlyExpression>>,
         index: Box<Located<EarlyIndex>>,
     },
+    Tuple(Located<Vec<Located<EarlyExpression>>>),
 }
 
 #[derive(Debug)]
-pub enum EarlyStamementLhs {
+pub enum EarlyStatementLhs {
     Ident(Located<EarlyIdentifier>),
+    Tuple(Located<Vec<Located<EarlyIdentifier>>>),
     // TODO Add slice as a LHS?
 }
 
 #[derive(Debug)]
 pub enum EarlyStatement {
     Affect {
-        lhs: EarlyStamementLhs,
+        lhs: EarlyStatementLhs,
         rhs: Box<Located<EarlyExpression>>,
     },
     IfThenElse {
         condition: Box<Located<EarlyExpression>>,
-        if_block: Located<Block>,
-        else_block: Option<Located<Block>>,
-    }
+        if_block: Located<EarlyBlock>,
+        else_block: Option<Located<EarlyBlock>>,
+    },
 }
 
-pub type Block = Vec<Located<EarlyStatement>>;
+pub type EarlyBlock = Vec<Located<EarlyStatement>>;
 
 #[derive(Debug)]
 pub struct EarlyRuntimeArg {
-    name: Located<EarlyIdentifier>,
-    size: Option<usize>,
+    pub name: Located<EarlyIdentifier>,
+    pub typ: Option<Located<EarlyExpression>>,
 }
 
 #[derive(Debug)]
@@ -113,15 +120,15 @@ pub enum EarlyStaticType {
 
 #[derive(Debug)]
 pub struct EarlyStaticArg {
-    name: Located<EarlyIdentifier>,
-    typ: Option<Located<EarlyStaticType>>,
+    pub name: Located<EarlyIdentifier>,
+    pub typ: Option<Located<EarlyStaticType>>,
 }
 
 #[derive(Debug)]
 pub struct EarlyNode {
-    name: Located<EarlyIdentifier>,
-    static_args: Located<Vec<Located<EarlyStaticArg>>>,
-    runtime_args: Located<Vec<Located<EarlyRuntimeArg>>>,
-    runtime_outs: Located<Vec<Located<EarlyRuntimeArg>>>,
-    block: Located<Block>,
+    pub name: Located<EarlyIdentifier>,
+    pub static_args: Option<Located<Vec<Located<EarlyStaticArg>>>>,
+    pub runtime_args: Located<Vec<Located<EarlyRuntimeArg>>>,
+    pub runtime_outs: Located<Vec<Located<EarlyRuntimeArg>>>,
+    pub block: Located<EarlyBlock>,
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -39,7 +39,7 @@ pub enum EarlyMonOp {
 
 /// A immediate
 #[derive(Debug)]
-pub enum EarlyImmediate {
+pub enum EarlyLiteral {
     Int(usize),
     Bool(bool),
 }
@@ -57,7 +57,7 @@ pub enum EarlyIndex {
 #[derive(Debug)]
 pub enum EarlyExpression {
     Ident(Located<EarlyIdentifier>),
-    Immediate(Located<EarlyImmediate>),
+    Literal(Located<EarlyLiteral>),
     MonOp {
         operand: Box<Located<EarlyExpression>>,
         operator: Located<EarlyMonOp>,
@@ -115,13 +115,6 @@ pub enum EarlyStaticType {
 pub struct EarlyStaticArg {
     name: Located<EarlyIdentifier>,
     typ: Option<Located<EarlyStaticType>>,
-}
-
-#[derive(Debug)]
-pub struct EarlyFunc {
-    name: Located<EarlyIdentifier>,
-    args: Located<Vec<Located<EarlyStaticArg>>>,
-    return_type: Located<EarlyStaticType>,
 }
 
 #[derive(Debug)]

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -6,11 +6,21 @@ pub type EarlyIdentifier = String;
 /// The type for function parameters
 pub type EarlyParams = Vec<Located<EarlyExpression>>;
 
+pub type EarlyStaticParams = Vec<Located<EarlyStaticExpression>>;
+
 pub type EarlyProgram = Vec<Located<EarlyNode>>;
 
 /// A 2-adic operator
 #[derive(Debug)]
 pub enum EarlyBinOp {
+    Concat,
+    BitOr,
+    BitAnd,
+    BitXOr,
+}
+
+#[derive(Debug)]
+pub enum EarlyStaticBinOp {
     Plus,
     Minus,
     Div,
@@ -18,16 +28,8 @@ pub enum EarlyBinOp {
     Modulo,
     Or,
     And,
-    Smaller,
-    SmallerEq,
-    Greater,
-    GreaterEq,
     Equals,
     NEquals,
-    Concat,
-    BitOr,
-    BitAnd,
-    BitXOr,
 }
 
 #[derive(Debug)]
@@ -38,14 +40,23 @@ pub enum EarlyOperator {
 /// A 1-adic operator
 #[derive(Debug)]
 pub enum EarlyMonOp {
+    BitNot,
+}
+
+#[derive(Debug)]
+pub enum EarlyStaticMonOp {
     Minus,
     Not,
-    BitNot,
 }
 
 /// A immediate
 #[derive(Debug)]
 pub enum EarlyLiteral {
+    Int(usize),
+}
+
+#[derive(Debug)]
+pub enum EarlyStaticLiteral {
     Int(usize),
     Bool(bool),
 }
@@ -53,11 +64,11 @@ pub enum EarlyLiteral {
 #[derive(Debug)]
 pub enum EarlyIndex {
     Range {
-        lhs: Option<Located<EarlyExpression>>,
-        rhs: Option<Located<EarlyExpression>>,
+        lhs: Option<Located<EarlyStaticExpression>>,
+        rhs: Option<Located<EarlyStaticExpression>>,
         rhs_inclusive: bool,
     },
-    Simple(Located<EarlyExpression>),
+    Simple(EarlyStaticExpression),
 }
 
 #[derive(Debug)]
@@ -75,14 +86,39 @@ pub enum EarlyExpression {
     },
     FuncCall {
         func_name: Located<EarlyIdentifier>,
-        static_params: EarlyParams,
+        static_params: Option<EarlyStaticParams>,
         runtime_params: EarlyParams,
     },
     Index {
         lhs: Box<Located<EarlyExpression>>,
         index: Box<Located<EarlyIndex>>,
     },
-    Tuple(Located<Vec<Located<EarlyExpression>>>),
+    Tuple(Vec<Located<EarlyExpression>>),
+    IfThenElse {
+        condition: Box<Located<EarlyStaticExpression>>,
+        if_block: Box<Located<EarlyExpression>>,
+        else_block: Box<Located<EarlyExpression>>,
+    },
+}
+
+#[derive(Debug)]
+pub enum EarlyStaticExpression {
+    Ident(EarlyIdentifier),
+    Literal(EarlyStaticLiteral),
+    MonOp {
+        operand: Box<Located<EarlyStaticExpression>>,
+        operator: Located<EarlyStaticMonOp>,
+    },
+    BinOp {
+        lhs: Box<Located<EarlyStaticExpression>>,
+        rhs: Box<Located<EarlyStaticExpression>>,
+        operator: Located<EarlyStaticBinOp>,
+    },
+    IfThenElse {
+        condition: Box<Located<EarlyStaticExpression>>,
+        if_block: Box<Located<EarlyStaticExpression>>,
+        else_block: Box<Located<EarlyStaticExpression>>,
+    },
 }
 
 #[derive(Debug)]
@@ -99,9 +135,9 @@ pub enum EarlyStatement {
         rhs: Box<Located<EarlyExpression>>,
     },
     IfThenElse {
-        condition: Box<Located<EarlyExpression>>,
+        condition: Box<Located<EarlyStaticExpression>>,
         if_block: Located<EarlyBlock>,
-        else_block: Option<Located<EarlyBlock>>,
+        else_block: Located<EarlyBlock>,
     },
 }
 
@@ -110,7 +146,7 @@ pub type EarlyBlock = Vec<Located<EarlyStatement>>;
 #[derive(Debug)]
 pub struct EarlyRuntimeArg {
     pub name: Located<EarlyIdentifier>,
-    pub typ: Option<Located<EarlyExpression>>,
+    pub typ: Option<Located<EarlyStaticExpression>>,
 }
 
 #[derive(Debug)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,1 +1,74 @@
 mod ast;
+
+use crate::common::location::*;
+use ast::*;
+use anyhow::{anyhow, Context, Result};
+use std::{sync::Arc, path::PathBuf};
+use ariadne::{Source, FileCache};
+
+extern crate peg;
+
+peg::parser! {
+    grammar macrojazz() for Vec<String> {
+        // Whitespace
+        rule _ = [' ' | '\n' | '\t']* comment()*
+
+        rule comment() -> ()
+            = "//" [^'\n']*
+
+        pub rule program(file: &Arc<Source>) -> EarlyProgram
+            = _ d:node_declaration(file)* _ { d }
+
+        rule ident(file: &Arc<Source>) -> Located<EarlyIdentifier>
+            = _ start:position!()
+                !"node"
+                !"if"
+                !"else"
+                !"end"
+                v:$(['a'..='z' | 'A'..='Z']*)
+                end:position!() _
+                {
+                    Located::new(v.to_string(), file, start, end)
+                }
+        rule int_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+            = _ start:position!() i:$(['0'..='9']) end:position!() _
+            {?
+                Ok(Located::new(EarlyLiteral::Int(i.parse().or(Err("Int problem"))?),
+                file, start, end))
+            }
+
+        rule bool_true_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+            = _ start:position!() "true" end:position!() _
+            {
+                Located::new(EarlyLiteral::Bool(true), file, start, end)
+            }
+
+        rule bool_false_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+            = _ start:position!() "false" end:position!() _
+            {
+                Located::new(EarlyLiteral::Bool(false), file, start, end)
+            }
+
+        rule bool_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+            = bool_true_literal(file)
+            / bool_false_literal(file)
+
+        rule literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+            = bool_literal(file)
+            / int_literal(file)
+
+        // rule node_declaration(file: &Arc<Source>) -> Located:Whitespace
+    }
+}
+
+fn parse_single_source(file_ref: &Arc<Source>, file_source: String,)
+
+pub fn parse_sources(sources: Vec<PathBuf>) -> Result<(EarlyProgram, FileCache)> {
+    let mut filecache = FileCache::default();
+
+    for src in sources {
+        
+    }
+
+    todo!()
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,74 +1,221 @@
 mod ast;
 
 use crate::common::location::*;
-use ast::*;
 use anyhow::{anyhow, Context, Result};
-use std::{sync::Arc, path::PathBuf};
-use ariadne::{Source, FileCache};
+use ariadne::{FileCache, Source};
+pub use ast::*;
+use peg::str::LineCol;
+use std::{path::PathBuf, sync::Arc};
 
 extern crate peg;
 
 peg::parser! {
-    grammar macrojazz() for Vec<String> {
+    grammar macrojazz() for str {
         // Whitespace
         rule _ = [' ' | '\n' | '\t']* comment()*
 
         rule comment() -> ()
             = "//" [^'\n']*
 
-        pub rule program(file: &Arc<Source>) -> EarlyProgram
-            = _ d:node_declaration(file)* _ { d }
+        pub rule program(file: SrcId) -> EarlyProgram
+            = _ d:node(file)* _ { d }
 
-        rule ident(file: &Arc<Source>) -> Located<EarlyIdentifier>
+        rule ident(file: SrcId) -> Located<EarlyIdentifier>
             = _ start:position!()
                 !"node"
                 !"if"
                 !"else"
                 !"end"
+                !"true"
+                !"false"
                 v:$(['a'..='z' | 'A'..='Z']*)
                 end:position!() _
                 {
                     Located::new(v.to_string(), file, start, end)
                 }
-        rule int_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
-            = _ start:position!() i:$(['0'..='9']) end:position!() _
+        rule int10_literal(file: SrcId) -> Located<EarlyLiteral>
+            = _ start:position!() i:$(['0'..='9']*) end:position!() _
             {?
                 Ok(Located::new(EarlyLiteral::Int(i.parse().or(Err("Int problem"))?),
                 file, start, end))
             }
 
-        rule bool_true_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+        rule int16_literal(file: SrcId) -> Located<EarlyLiteral>
+            = _ start:position!() "0x" i:$(['0'..='9' | 'a'..='f' | 'A'..='F']*) end:position!() _
+            {?
+                Ok(Located::new(EarlyLiteral::Int(usize::from_str_radix(i, 16).or(Err("Int problem"))?),
+                file, start, end))
+            }
+
+        rule int8_literal(file: SrcId) -> Located<EarlyLiteral>
+            = _ start:position!() "0o" i:$(['0'..='7']*) end:position!() _
+            {?
+                Ok(Located::new(EarlyLiteral::Int(usize::from_str_radix(i, 8).or(Err("Int problem"))?),
+                file, start, end))
+            }
+
+        rule int2_literal(file: SrcId) -> Located<EarlyLiteral>
+            = _ start:position!() "0b" i:$(['0'..='1']*) end:position!() _
+            {?
+                Ok(Located::new(EarlyLiteral::Int(usize::from_str_radix(i, 2).or(Err("Int problem"))?),
+                file, start, end))
+            }
+
+        rule int_literal(file: SrcId) -> Located<EarlyLiteral>
+            = int2_literal(file)
+            / int8_literal(file)
+            / int10_literal(file)
+            / int16_literal(file)
+
+        rule bool_true_literal(file: SrcId) -> Located<EarlyLiteral>
             = _ start:position!() "true" end:position!() _
             {
                 Located::new(EarlyLiteral::Bool(true), file, start, end)
             }
 
-        rule bool_false_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+        rule bool_false_literal(file: SrcId) -> Located<EarlyLiteral>
             = _ start:position!() "false" end:position!() _
             {
                 Located::new(EarlyLiteral::Bool(false), file, start, end)
             }
 
-        rule bool_literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+        rule bool_literal(file: SrcId) -> Located<EarlyLiteral>
             = bool_true_literal(file)
             / bool_false_literal(file)
 
-        rule literal(file: &Arc<Source>) -> Located<EarlyLiteral>
+        rule literal(file: SrcId) -> Located<EarlyLiteral>
             = bool_literal(file)
             / int_literal(file)
 
-        // rule node_declaration(file: &Arc<Source>) -> Located:Whitespace
+        rule expression(file: SrcId) -> Located<EarlyExpression> = precedence! {
+                start:position!() "!" end:position!() _ x:@ {
+                    let loc = x.get_loc();
+                    Located::empty_from_range(EarlyExpression::MonOp {
+                        operator: Located::empty_from_range(EarlyMonOp::Not, start..end),
+                        operand: Box::new(x),
+                    }, start..(loc.get_range().end))
+                }
+
+                --
+
+                l:literal(file) { let loc = l.get_loc(); Located::from_range(EarlyExpression::Literal(l.get_inner()), file, loc.get_range()) }
+                i:ident(file) { let loc = i.get_loc(); Located::from_range(EarlyExpression::Ident(i.get_inner()), file, loc.get_range()) }
+            }
+
+        rule runtime_type(file: SrcId) -> Located<EarlyExpression>
+            = _ start:position!() "[" exp:expression(file) "]" end:position!() _
+            {
+                exp
+            }
+
+        rule runtime_type_annot(file: SrcId) -> Located<EarlyExpression>
+            = _ start:position!() ":" _ r:runtime_type(file) end:position!() _
+            {
+                r
+            }
+
+        rule runtime_arg(file: SrcId) -> Located<EarlyRuntimeArg>
+            = _ start:position!() i:ident(file) typ:runtime_type_annot(file)? end:position!() _
+            {
+                Located::new(EarlyRuntimeArg { name: i, typ }, file, start, end)
+            }
+
+        rule runtime_arg_vec(file: SrcId) -> Located<Vec<Located<EarlyRuntimeArg>>>
+            = start:position!() "(" args:runtime_arg(file) ** "," ")" end:position!()
+            {
+                Located::new(args, file, start, end)
+            }
+
+        rule static_type_bool(file:SrcId) -> Option<Located<EarlyStaticType>>
+            = _ start:position!() "bool" end:position!() _
+            {
+                Some(Located::new(EarlyStaticType::Bool, file, start, end))
+            }
+
+        rule static_type_int(file:SrcId) -> Option<Located<EarlyStaticType>>
+            = _ start:position!() "int" end:position!() _
+            {
+                Some(Located::new(EarlyStaticType::Int, file, start, end))
+            }
+
+        rule static_type(file: SrcId) -> Option<Located<EarlyStaticType>>
+            = static_type_bool(file)
+            / static_type_int(file)
+            / { None }
+
+        rule static_arg(file: SrcId) -> Located<EarlyStaticArg>
+            = _ start:position!() i:ident(file) _ ":" _ t:static_type(file) end:position!() _
+            {
+                Located::new(EarlyStaticArg { name: i, typ: t }, file, start, end)
+            }
+
+        rule static_arg_vec(file: SrcId) -> Located<Vec<Located<EarlyStaticArg>>>
+            = _ start:position!() "<" _ a:static_arg(file) ** "," _ ">" end:position!()
+            {
+                Located::new(a, file, start, end)
+            }
+
+        rule lhs_ident(file: SrcId) -> EarlyStatementLhs
+            = i:ident(file)
+            {
+                EarlyStatementLhs::Ident(i)
+            }
+
+        rule lhs_tuple(file: SrcId) -> EarlyStatementLhs
+            = _ start:position!() "(" _ i:ident(file) ** "," _ ")" end:position!() _
+            {
+                EarlyStatementLhs::Tuple(Located::new(i, file, start, end))
+            }
+
+        rule lhs(file: SrcId) -> EarlyStatementLhs
+            = lhs_tuple(file)
+            / lhs_ident(file)
+
+        rule statement_affect(file: SrcId) -> Located<EarlyStatement>
+            = _ start:position!() l:lhs(file) "=" e:expression(file) ";" end:position!() _
+            {
+                Located::new(EarlyStatement::Affect { lhs: l, rhs: Box::new(e) }, file, start, end)
+            }
+
+        rule statement(file: SrcId) -> Located<EarlyStatement>
+            = statement_affect(file)
+
+        rule block(file: SrcId) -> Located<EarlyBlock>
+            = _ start:position!() b:statement(file)* end:position!() _
+            {
+                Located::new(b, file, start, end)
+            }
+
+        rule node(file: SrcId) -> Located<EarlyNode>
+            = _ start:position!() "node" _ i:ident(file) s_args:static_arg_vec(file)? r_args:runtime_arg_vec(file)
+                _ "->" _ r_outs:runtime_arg_vec(file) _ "{" b:block(file) "}" end:position!() _
+            {
+                Located::new(EarlyNode {
+                    name: i,
+                    static_args: s_args,
+                    runtime_args: r_args,
+                    runtime_outs: r_outs,
+                    block: b,
+                }, file, start, end)
+            }
     }
 }
 
-fn parse_single_source(file_ref: &Arc<Source>, file_source: String,)
+pub fn parse_single(
+    source_str: &str,
+    src: SrcId,
+) -> Result<EarlyProgram, peg::error::ParseError<LineCol>> {
+    macrojazz::program(source_str, src)
+}
+
+fn parse_single_source(source: &str) -> Result<EarlyProgram> {
+    todo!()
+}
 
 pub fn parse_sources(sources: Vec<PathBuf>) -> Result<(EarlyProgram, FileCache)> {
     let mut filecache = FileCache::default();
 
-    for src in sources {
-        
-    }
+    for src in sources {}
 
     todo!()
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,10 +25,9 @@ peg::parser! {
                 !"node"
                 !"if"
                 !"else"
-                !"end"
                 !"true"
                 !"false"
-                v:quiet!{$(['a'..='z' | 'A'..='Z']*)}
+                v:quiet!{$(['a'..='z' | 'A'..='Z']+)}
                 end:position!() _
                 {
                     Located::new(v.to_string(), file, start, end)
@@ -64,44 +63,70 @@ peg::parser! {
         rule int_literal(file: SrcId) -> Located<EarlyLiteral>
             = int2_literal(file)
             / int8_literal(file)
-            / int10_literal(file)
             / int16_literal(file)
+            / int10_literal(file)
 
-        rule bool_true_literal(file: SrcId) -> Located<EarlyLiteral>
+        rule bool_true_literal(file: SrcId) -> Located<EarlyStaticLiteral>
             = _ start:position!() "true" end:position!() _
             {
-                Located::new(EarlyLiteral::Bool(true), file, start, end)
+                Located::new(EarlyStaticLiteral::Bool(true), file, start, end)
             }
 
-        rule bool_false_literal(file: SrcId) -> Located<EarlyLiteral>
+        rule bool_false_literal(file: SrcId) -> Located<EarlyStaticLiteral>
             = _ start:position!() "false" end:position!() _
             {
-                Located::new(EarlyLiteral::Bool(false), file, start, end)
+                Located::new(EarlyStaticLiteral::Bool(false), file, start, end)
             }
 
-        rule bool_literal(file: SrcId) -> Located<EarlyLiteral>
+        rule bool_literal(file: SrcId) -> Located<EarlyStaticLiteral>
             = bool_true_literal(file)
             / bool_false_literal(file)
 
-        rule literal(file: SrcId) -> Located<EarlyLiteral>
+        rule static_literal(file: SrcId) -> Located<EarlyStaticLiteral>
             = bool_literal(file)
-            / int_literal(file)
+            / (i:int_literal(file) { i.map(|EarlyLiteral::Int(int)| EarlyStaticLiteral::Int(int) ) })
 
-        rule expression(file: SrcId) -> Located<EarlyExpression> = precedence! {
+        rule literal(file: SrcId) -> Located<EarlyLiteral>
+            = int_literal(file)
+
+        rule incl_range(file: SrcId) -> Located<EarlyIndex>
+            = _ start:position!() e1:static_expression(file)? _ "..=" e2:static_expression(file)? end:position!() _
+            {
+                Located::new(
+                    EarlyIndex::Range {
+                        lhs: e1,
+                        rhs: e2,
+                        rhs_inclusive: true
+                    },
+                    file,
+                    start,
+                    end)
+            }
+
+        rule excl_range(file: SrcId) -> Located<EarlyIndex>
+            = _ start:position!() e1:static_expression(file)? _ ".." !"=" e2:static_expression(file)? end:position!() _
+            {
+                Located::new(
+                    EarlyIndex::Range {
+                        lhs: e1,
+                        rhs: e2,
+                        rhs_inclusive: false
+                    },
+                    file,
+                    start,
+                    end)
+            }
+
+        rule index(file: SrcId) -> Located<EarlyIndex>
+            = incl_range(file)
+            / excl_range(file)
+            / (e: static_expression(file) { e.map(|exp| EarlyIndex::Simple(exp)) })
+
+        rule static_expression(file: SrcId) -> Located<EarlyStaticExpression> = precedence! {
                 start:position!() "!" end:position!() _ x:@ {
                     let loc = x.get_loc();
-                    Located::empty_from_range(EarlyExpression::MonOp {
-                        operator: Located::empty_from_range(EarlyMonOp::Not, start..end),
-                        operand: Box::new(x),
-                    }, loc.extend(start, end))
-                }
-
-                --
-
-                start:position!() "~" end:position!() _ x:@ {
-                    let loc = x.get_loc();
-                    Located::empty_from_range(EarlyExpression::MonOp {
-                        operator: Located::empty_from_range(EarlyMonOp::BitNot, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::MonOp {
+                        operator: Located::empty_from_range(EarlyStaticMonOp::Not, start..end),
                         operand: Box::new(x),
                     }, loc.extend(start, end))
                 }
@@ -110,8 +135,8 @@ peg::parser! {
 
                 start:position!() "-" end:position!() _ x:@ {
                     let loc = x.get_loc();
-                    Located::empty_from_range(EarlyExpression::MonOp {
-                        operator: Located::empty_from_range(EarlyMonOp::Minus, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::MonOp {
+                        operator: Located::empty_from_range(EarlyStaticMonOp::Minus, start..end),
                         operand: Box::new(x),
                     }, loc.extend(start, end))
                 }
@@ -121,8 +146,8 @@ peg::parser! {
                x:(@) _ start:position!() "==" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::Equals, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Equals, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
@@ -131,8 +156,8 @@ peg::parser! {
                x:(@) _ start:position!() "!=" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::NEquals, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::NEquals, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
@@ -140,45 +165,183 @@ peg::parser! {
 
                 --
 
-               x:(@) _ start:position!() ">" end:position!() _ y:@ {
+               x:(@) _ start:position!() "+" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::Greater, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Plus, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
                 }
 
-               x:(@) _ start:position!() ">=" end:position!() _ y:@ {
+               x:(@) _ start:position!() "-" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::GreaterEq, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Minus, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
                 }
 
-               x:(@) _ start:position!() "<" end:position!() _ y:@ {
+                 --
+                     
+               x:(@) _ start:position!() "*" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::Smaller, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Mult, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
                 }
 
-               x:(@) _ start:position!() "<=" end:position!() _ y:@ {
+               x:(@) _ start:position!() "/" end:position!() _ y:@ {
                     let loc_x = x.get_loc();
                     let loc_y = y.get_loc();
-                    Located::empty_from_range(EarlyExpression::BinOp {
-                        operator: Located::empty_from_range(EarlyBinOp::SmallerEq, start..end),
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Div, start..end),
                         lhs: Box::new(x),
                         rhs: Box::new(y),
                     }, loc_x.union(loc_y))
                 }
+
+               x:(@) _ start:position!() "%" end:position!() _ y:@ {
+                    let loc_x = x.get_loc();
+                    let loc_y = y.get_loc();
+                    Located::empty_from_range(EarlyStaticExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyStaticBinOp::Modulo, start..end),
+                        lhs: Box::new(x),
+                        rhs: Box::new(y),
+                    }, loc_x.union(loc_y))
+                }
+
+
+                 --
+
+                l:static_literal(file)
+                    {
+                        let loc = l.get_loc();
+                        Located::from_range(EarlyStaticExpression::Literal(l.get_inner()), file, loc.get_range())
+                    }
+
+                i:ident(file)
+                    {
+                        let loc = i.get_loc();
+                        Located::from_range(EarlyStaticExpression::Ident(i.get_inner()), file, loc.get_range())
+                    }
+
+                --
+
+                _ start:position!() "if" _ s:static_expression(file) _ "{"
+                    if_block:static_expression(file) "}" _ "else" 
+                    _ "{" else_block:static_expression(file) "}" end:position!() _
+                    {
+                        Located::new(
+                            EarlyStaticExpression::IfThenElse {
+                                condition: Box::new(s),
+                                if_block: Box::new(if_block),
+                                else_block: Box::new(else_block),
+                            },
+                            file,
+                            start,
+                            end
+                            )
+                    }
+
+                --
+
+
+                _ start:position!() "(" _ e:static_expression(file) _ ")" end:position!() _
+                {
+                    e
+                }
+
+            } 
+
+        rule expression(file: SrcId) -> Located<EarlyExpression> = precedence! {
+                start:position!() "~" end:position!() _ x:@ {
+                    let loc = x.get_loc();
+                    Located::empty_from_range(EarlyExpression::MonOp {
+                        operator: Located::empty_from_range(EarlyMonOp::BitNot, start..end),
+                        operand: Box::new(x),
+                    }, loc.extend(start, end))
+                }
+
+                 --
+
+               x:(@) _ start:position!() "|" end:position!() _ y:@ {
+                    let loc_x = x.get_loc();
+                    let loc_y = y.get_loc();
+                    Located::empty_from_range(EarlyExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyBinOp::BitOr, start..end),
+                        lhs: Box::new(x),
+                        rhs: Box::new(y),
+                    }, loc_x.union(loc_y))
+                }
+
+                 --
+
+
+               x:(@) _ start:position!() "&" end:position!() _ y:@ {
+                    let loc_x = x.get_loc();
+                    let loc_y = y.get_loc();
+                    Located::empty_from_range(EarlyExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyBinOp::BitAnd, start..end),
+                        lhs: Box::new(x),
+                        rhs: Box::new(y),
+                    }, loc_x.union(loc_y))
+                }
+
+               x:(@) _ start:position!() "^" end:position!() _ y:@ {
+                    let loc_x = x.get_loc();
+                    let loc_y = y.get_loc();
+                    Located::empty_from_range(EarlyExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyBinOp::BitXOr, start..end),
+                        lhs: Box::new(x),
+                        rhs: Box::new(y),
+                    }, loc_x.union(loc_y))
+                }
+
+                --
+
+               x:(@) _ start:position!() "." end:position!() _ y:@ {
+                    let loc_x = x.get_loc();
+                    let loc_y = y.get_loc();
+                    Located::empty_from_range(EarlyExpression::BinOp {
+                        operator: Located::empty_from_range(EarlyBinOp::Concat, start..end),
+                        lhs: Box::new(x),
+                        rhs: Box::new(y),
+                    }, loc_x.union(loc_y))
+                }
+
+                --
+
+                 _ start:position!() i:ident(file) s_args:("<" _ e:static_expression(file) ** "," _ ">" { e })? "(" _ r_args:expression(file) ** "," _ ")" end:position!() _ {
+                         println!("Parsing function call.");
+                         Located::new(
+                             EarlyExpression::FuncCall { 
+                                 func_name: i, 
+                                 static_params: s_args, 
+                                 runtime_params: r_args },
+                                 file,
+                                 start,
+                                 end)
+                     }
+
+                e:@ "[" i:index(file) "]" end:position!() _
+                {
+                    let loc = e.get_loc();
+                    Located::empty_from_range(
+                        EarlyExpression::Index {
+                            lhs: Box::new(e),
+                            index: Box::new(i),
+                        },
+                        loc.get_range().start..end)
+                }
+
+                 --
 
                 l:literal(file)
                     {
@@ -192,15 +355,47 @@ peg::parser! {
                         Located::from_range(EarlyExpression::Ident(i.get_inner()), file, loc.get_range())
                     }
 
+                --
+
+                _ start:position!() 
+                    "if" _ s:static_expression(file) _ "{" _ if_block:expression(file) _ "}" _
+                    "else" _ "{" _ else_block:expression(file) _ "}" _
+                    end:position!() _
+                    {
+                        Located::new(
+                            EarlyExpression::IfThenElse {
+                                condition: Box::new(s),
+                                if_block: Box::new(if_block),
+                                else_block: Box::new(else_block),
+                            },
+                            file,
+                            start,
+                            end,
+                            )
+                    }
+
+                _ start:position!() "(" _ e:expression(file) ++ "," _ ")" end:position!() _
+                {
+                    if e.len() == 1 {
+                        e.into_iter().next().unwrap()
+                    } else {
+                        Located::new(
+                            EarlyExpression::Tuple(e),
+                            file,
+                            start,
+                            end)
+                    }
+                }
+
             }
 
-        rule runtime_type(file: SrcId) -> Located<EarlyExpression>
-            = _ start:position!() "[" exp:expression(file) "]" end:position!() _
+        rule runtime_type(file: SrcId) -> Located<EarlyStaticExpression>
+            = _ start:position!() "[" exp:static_expression(file) "]" end:position!() _
             {
                 exp
             }
 
-        rule runtime_type_annot(file: SrcId) -> Located<EarlyExpression>
+        rule runtime_type_annot(file: SrcId) -> Located<EarlyStaticExpression>
             = _ start:position!() ":" _ r:runtime_type(file) end:position!() _
             {
                 r
@@ -219,13 +414,13 @@ peg::parser! {
             }
 
         rule static_type_bool(file:SrcId) -> Option<Located<EarlyStaticType>>
-            = _ start:position!() "bool" end:position!() _
+            = _ start:position!() ":" _ "bool" end:position!() _
             {
                 Some(Located::new(EarlyStaticType::Bool, file, start, end))
             }
 
         rule static_type_int(file:SrcId) -> Option<Located<EarlyStaticType>>
-            = _ start:position!() "int" end:position!() _
+            = _ start:position!() ":" _ "int" end:position!() _
             {
                 Some(Located::new(EarlyStaticType::Int, file, start, end))
             }
@@ -236,7 +431,7 @@ peg::parser! {
             / { None }
 
         rule static_arg(file: SrcId) -> Located<EarlyStaticArg>
-            = _ start:position!() i:ident(file) _ ":" _ t:static_type(file) end:position!() _
+            = _ start:position!() i:ident(file) _ t:static_type(file) end:position!() _
             {
                 Located::new(EarlyStaticArg { name: i, typ: t }, file, start, end)
             }
@@ -269,8 +464,26 @@ peg::parser! {
                 Located::new(EarlyStatement::Affect { lhs: l, rhs: Box::new(e) }, file, start, end)
             }
 
+        rule statement_if_then_else(file: SrcId) -> Located<EarlyStatement>
+            = _ start:position!() "if" _ s:static_expression(file) _ "{"
+                if_block:block(file) "}" _ "else" _ "{" else_block:block(file) "}"
+                end:position!() _
+                {
+                    Located::new(
+                        EarlyStatement::IfThenElse {
+                            condition: Box::new(s),
+                            if_block,
+                            else_block,
+                        },
+                        file,
+                        start,
+                        end
+                        )
+                }
+
         rule statement(file: SrcId) -> Located<EarlyStatement>
             = statement_affect(file)
+            / statement_if_then_else(file)
 
         rule block(file: SrcId) -> Located<EarlyBlock>
             = _ start:position!() b:statement(file)* end:position!() _
@@ -310,4 +523,122 @@ pub fn parse_sources(sources: Vec<PathBuf>) -> Result<(EarlyProgram, FileCache)>
     for src in sources {}
 
     todo!()
+}
+
+#[cfg(test)]
+mod test {
+    use super::{parse_single, SrcId};
+
+    fn run(code: &str) {
+        parse_single(code, SrcId::empty()).unwrap();
+    }
+
+    #[test]
+    fn empty_node() {
+        let code = r"
+node f() -> () {
+
+}
+        ";
+        run(code);
+    }
+
+
+    #[test]
+    fn io_node() {
+        let code = r"
+node f(a: [1], b: [n]) -> (c, d:[42]) {
+
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn static_arg_node() {
+        let code = r"
+node f<n, m: bool>() -> () {
+
+}
+        ";
+        run(code);
+    }
+ 
+    #[test]
+    fn static_runtime_combined_node() {
+        let code = r"
+node f<n, m: bool>(a: [n], b: [m]) -> (c: [n]) {
+
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn affect_node() {
+        let code = r"
+node f<n>(a) -> (b) {
+    b = a;
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn runtime_ops() {
+        let code = r"
+node f<n>(a) -> (b) {
+    b = (a . a) ^ c | d;
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn runtime_range() {
+        let code = r"
+node f<n>(a) -> (b) {
+    b = a[0..];
+    b = a[3..n];
+    b = a[(n - 1)..=69 + n];
+    b = a[42];
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn runtime_ifthenelse() {
+        let code = r"
+node f<n>(a) -> (b) {
+    b = if n == 42 { a } else { ~a };
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn complex_runtime() {
+        let code = r"
+node f<n>(a) -> (b) {
+    b = (a . 0b100110)[12..=n] & if n != 0xa2 { 0b1 } else { 0b10 };
+    b = g<if n == 42 { 12 } else { 0o123 }>(a[..34]);
+}
+        ";
+        run(code);
+    }
+
+    #[test]
+    fn statement_ifthenelse() {
+        let code = r"
+node f<n>(a) -> (b) {
+    if n == 0 {
+        b = 0;
+    } else {
+        b = a . 0x23[..3];
+    }
+}
+        ";
+        run(code);
+    }
 }


### PR DESCRIPTION
After experimenting with both `peg` and `chumsky`, `peg` seems easier to use, although a bit less powerful than `chumsky` (e.g. we have coarser control over parsing errors). Merge this branch into `main` to use `peg` in the project, as least on a mid-term scale.

Also add a basic CI.